### PR TITLE
Added special error page for when scanning valid certificates of wrong type in border control mode

### DIFF
--- a/FHICORC.Core/Services/Enum/TokenValidateResult.cs
+++ b/FHICORC.Core/Services/Enum/TokenValidateResult.cs
@@ -4,6 +4,7 @@
     {
         Invalid,
         Expired,
-        Valid
+        Valid,
+        UnsupportedType
     }
 }

--- a/FHICORC/Locales/en.json
+++ b/FHICORC/Locales/en.json
@@ -69,6 +69,7 @@
   "SCANNER_ERROR_EXPIRED_CONTENT_2": "Ask the person to open the COVID-19 certificate on helsenorge.no",
   "SCANNER_ERROR_INVALID_TITLE": "Invalid",
   "SCANNER_ERROR_INVALID_CONTENT": "The COVID-19 certificate is invalid.",
+  "SCANNER_ERROR_UNKNOWN_TYPE_CONTENT": "The certificate is not valid for border control. In border control the app will only validate EU/EEC codes.",
   "SCANNER_ERROR_BUTTON_TEXT": "Scan again",
   "MENU_TITLE": "Menu",
   "MENU_SETTINGS_PAGE": "Settings",

--- a/FHICORC/Locales/nb.json
+++ b/FHICORC/Locales/nb.json
@@ -69,6 +69,7 @@
   "SCANNER_ERROR_EXPIRED_CONTENT_2": "Be personen om å åpne koronasertifikatet på helsenorge.no.",
   "SCANNER_ERROR_INVALID_TITLE": "Ugyldig",
   "SCANNER_ERROR_INVALID_CONTENT": "Koronasertifikatet er ugyldig. ",
+  "SCANNER_ERROR_UNKNOWN_TYPE_CONTENT": "Sertifikatet er ikke gyldig for grensekontroll. I grensekontroll vil appen kun validere EU/EØS-koder.",
   "SCANNER_ERROR_BUTTON_TEXT": "Scan ny",
   "MENU_TITLE": "Meny",
   "MENU_SETTINGS_PAGE": "Innstillinger",

--- a/FHICORC/Locales/nn.json
+++ b/FHICORC/Locales/nn.json
@@ -69,6 +69,7 @@
   "SCANNER_ERROR_EXPIRED_CONTENT_2": "Be personen om å opne koronasertifikatet på helsenorge.no.",
   "SCANNER_ERROR_INVALID_TITLE": "Ugyldig",
   "SCANNER_ERROR_INVALID_CONTENT": "Koronasertifikatet er ikkje gyldig.",
+  "SCANNER_ERROR_UNKNOWN_TYPE_CONTENT": "Sertifikatet er ikkje gyldig for grensekontroll. I grensekontroll vil appen kun validera EU/EØS-kodar.",
   "SCANNER_ERROR_BUTTON_TEXT": "Skann ny",
   "MENU_TITLE": "Meny",
   "MENU_SETTINGS_PAGE": "Innstillingar",

--- a/FHICORC/ViewModels/QrScannerViewModels/ScannerErrorViewModel.cs
+++ b/FHICORC/ViewModels/QrScannerViewModels/ScannerErrorViewModel.cs
@@ -14,7 +14,10 @@ namespace FHICORC.ViewModels.QrScannerViewModels
     public class ScannerErrorViewModel : BaseScanViewModel
     {
         public string PageTitle => ShowInvalidPage ? "SCANNER_ERROR_INVALID_TITLE".Translate() : "SCANNER_ERROR_EXPIRED_TITLE".Translate();
-        public bool ShowInvalidPage => TokenValidateResultModel.ValidationResult == TokenValidateResult.Invalid;
+        public string InvalidContentText => TokenValidateResultModel.ValidationResult == TokenValidateResult.Invalid ? "SCANNER_ERROR_INVALID_CONTENT".Translate()
+            : "SCANNER_ERROR_UNKNOWN_TYPE_CONTENT".Translate();
+        public bool ShowInvalidPage => TokenValidateResultModel.ValidationResult == TokenValidateResult.Invalid
+            || TokenValidateResultModel.ValidationResult == TokenValidateResult.UnsupportedType;
         public TokenValidateResultModel TokenValidateResultModel { get; set; } = new TokenValidateResultModel();
 
         public string RepeatedText => string.Concat(Enumerable.Repeat(PageTitle.PadLeft(15), 10));
@@ -34,6 +37,7 @@ namespace FHICORC.ViewModels.QrScannerViewModels
             OnPropertyChanged(nameof(ShowInvalidPage));
             OnPropertyChanged(nameof(PageTitle));
             OnPropertyChanged(nameof(RepeatedText));
+            OnPropertyChanged(nameof(InvalidContentText));
 
             return base.InitializeAsync(navigationData);
         }

--- a/FHICORC/Views/ScannerPages/ScannerErrorPage.xaml
+++ b/FHICORC/Views/ScannerPages/ScannerErrorPage.xaml
@@ -124,7 +124,7 @@
                         <Label
                             HorizontalTextAlignment="Center"
                             Style="{StaticResource ContentStyle}"
-                            Text="{Binding Strings [SCANNER_ERROR_INVALID_CONTENT]}" >
+                            Text="{Binding InvalidContentText}" >
                         </Label>
                     </StackLayout>
                 </StackLayout>


### PR DESCRIPTION
If the QR codes signature is valid, but of wrong type we now display a special error page for this.

If the signature cannot be validated throw an error and display the existing invalid page, because we don't want to do any handling of codes we don't trust. 