### PR TITLE
Replacement of logo on SplashScreen

### DIFF
--- a/FHICORC.Android/Resources/drawable-v23/splash_screen_layout.xml
+++ b/FHICORC.Android/Resources/drawable-v23/splash_screen_layout.xml
@@ -3,5 +3,5 @@
 	<item>
 		<bitmap android:src="@drawable/splash_screen" android:tileMode="disabled" android:gravity="fill_horizontal|fill_vertical" />
 	</item>
-	<item android:gravity="center" android:bottom="50dp" android:drawable="@drawable/certificate_logo" />
+	<item android:gravity="center" android:bottom="100dp" android:drawable="@drawable/certificate_logo" />
 </layer-list>

--- a/FHICORC.Android/Resources/drawable/splash_screen_layout.xml
+++ b/FHICORC.Android/Resources/drawable/splash_screen_layout.xml
@@ -3,5 +3,5 @@
 	<item>
 		<bitmap android:src="@drawable/splash_screen" android:tileMode="disabled" android:gravity="fill_horizontal|fill_vertical" />
 	</item>
-	<item android:gravity="center" android:bottom="50dp" android:drawable="@drawable/certificate_logo" />
+	<item android:gravity="center" android:bottom="100dp" android:drawable="@drawable/certificate_logo" />
 </layer-list>

--- a/FHICORC.iOS/Resources/LaunchScreen.storyboard
+++ b/FHICORC.iOS/Resources/LaunchScreen.storyboard
@@ -25,7 +25,7 @@
 								<color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace" />
 							</imageView>
 							<imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="certificate_logo" translatesAutoresizingMaskIntoConstraints="NO" id="iLu-Vd-Ubj">
-								<rect key="frame" x="122" y="390" width="185" height="103.00000000000006" />
+								<rect key="frame" x="122" y="350" width="185" height="103.00000000000006" />
 								<constraints>
 									<constraint firstAttribute="width" constant="108" id="PKX-c6-HmW" />
 									<constraint firstAttribute="height" constant="75" id="guK-xE-Vng" />


### PR DESCRIPTION
[Splash logo misplacement](https://goto.netcompany.com/cases/GTE964/FHICORC/Lists/Bugs/DispForm.aspx?ID=51&Source=https%3A%2F%2Fgoto%2Enetcompany%2Ecom%2Fcases%2FGTE964%2FFHICORC%2FLists%2FBugs%2FMyDefects%2Easpx&ContentTypeId=0x0108001AE2A0D62F1AD24183A79DF91DF134DD)


<img width="700" alt="Screenshot 2021-07-12 at 13 10 58" src="https://user-images.githubusercontent.com/86463371/125416674-fc411102-4522-45ec-9c5b-a29a3f46df45.png">
