### PR TITLE
Made close button on error page visible

### DIFF
--- a/FHICORC/Views/BaseErrorPage.xaml
+++ b/FHICORC/Views/BaseErrorPage.xaml
@@ -100,9 +100,10 @@
                     IsVisible="{Binding HasSecondButton}"
                     Grid.Row="1"
                     Style="{StaticResource SecondaryButtonStyle}"
+                    BorderColor="{StaticResource FHIPrimaryWhite}"
                     Command="{Binding BackCommand}"
                     Text="{Binding SecondButtonTitle}"
-                    TextColor="{StaticResource FHIPrimaryBlue}"
+                    TextColor="{StaticResource FHIPrimaryWhite}"
                     effects:FontSizeLabelEffectParams.MaxFontSize="32"
                     effects:FontSizeLabelEffectParams.MinFontSize="12">
                     <controls:SingleLineButton.Effects>


### PR DESCRIPTION
[Defect 301: Close button missing on "no internet" screen](https://goto.netcompany.com/cases/GTE964/FHICORC/Lists/Bugs/DispForm.aspx?ID=301&ContentTypeId=0x0108001AE2A0D62F1AD24183A79DF91DF134DD)

![IMG_7675](https://user-images.githubusercontent.com/86482015/128329214-db4675a6-c394-4484-8c7c-8890f3326108.PNG)
