### PR TITLE
Moved banner down on scanner error page

### DIFF
--- a/FHICORC/Views/ScannerPages/ScannerErrorPage.xaml
+++ b/FHICORC/Views/ScannerPages/ScannerErrorPage.xaml
@@ -36,6 +36,7 @@
                 <StackLayout
                     BackgroundColor="{StaticResource ExpiredBorderColor}"
                     IsVisible="{Binding ShowInvalidPage, Converter={StaticResource BoolToInverseBoolConverter}}"
+                    Margin="0,20,0,0"
                     Padding="0,9,0,9"
                     Spacing="0">
                     <Label
@@ -55,6 +56,7 @@
                 <StackLayout
                     BackgroundColor="{StaticResource InvalidBorderColor}"
                     IsVisible="{Binding ShowInvalidPage}"
+                    Margin="0,20,0,0"
                     Padding="0,9,0,9"
                     Spacing="0">
                     <Label


### PR DESCRIPTION
[Defect 305: Invalid banner location discrepancy](https://goto.netcompany.com/cases/GTE964/FHICORC/Lists/Bugs/DispForm.aspx?ID=305&ContentTypeId=0x0108001AE2A0D62F1AD24183A79DF91DF134DD)
[Defect 306: Expired banner location discrepancy](https://goto.netcompany.com/cases/GTE964/FHICORC/Lists/Bugs/DispForm.aspx?ID=306&ContentTypeId=0x0108001AE2A0D62F1AD24183A79DF91DF134DD)

- Moved banner on expired and invalid scanner result down 

![IMG_7679](https://user-images.githubusercontent.com/86482015/128353020-72e3b252-ffd1-46e3-83c7-60e388f75a21.PNG)
