### PR TITLE
Changed button text on generic error screen

### DIFF
--- a/FHICORC/Services/Navigation/Errors.cs
+++ b/FHICORC/Services/Navigation/Errors.cs
@@ -11,7 +11,7 @@ namespace FHICORC.Services.Navigation
             Title = "ERROR_GENERIC_TITLE".Translate(),
             Message = "ERROR_GENERIC_TEXT".Translate(),
             Image = FHICORCImage.ErrorUnknown.Image(),
-            ButtonTitle = "ERROR_OK_BUTTON".Translate(),
+            ButtonTitle = "CLOSE_BUTTON".Translate(),
             HasSecondButton = false
         };
         public static readonly ErrorPageModel NoInternetError = new ErrorPageModel


### PR DESCRIPTION
[Defect 316: Something went wrong error screen: Button text is not correct](https://goto.netcompany.com/cases/GTE964/FHICORC/Lists/Bugs/DispForm.aspx?ID=316&ContentTypeId=0x0108001AE2A0D62F1AD24183A79DF91DF134DD)
- Changed button text on generic error screen from "OK" to "Close" 