### PR TITLE
Position button fix

### DIFF
--- a/FHICORC/Views/ScannerPages/QRScannerPage.xaml
+++ b/FHICORC/Views/ScannerPages/QRScannerPage.xaml
@@ -111,7 +111,7 @@
             </StackLayout>
             <StackLayout
                 Grid.Row="1"
-                Margin="20, 0, 20, 40"
+                Margin="20, 0, 20, 80"
                 VerticalOptions="End">
                 <effects:SingleLineButton
                 Text="{Binding ButtonText}"


### PR DESCRIPTION
[Camera permission declined screen: "Settings" button location discrepancy](https://goto.netcompany.com/cases/GTE964/FHICORC/Lists/Bugs/DispForm.aspx?ID=315&Source=https%3A%2F%2Fgoto%2Enetcompany%2Ecom%2Fcases%2FGTE964%2FFHICORC%2FLists%2FBugs%2FMyDefects%2Easpx&ContentTypeId=0x0108001AE2A0D62F1AD24183A79DF91DF134DD)


[Camera permission "next" button location discrepancy](https://goto.netcompany.com/cases/GTE964/FHICORC/Lists/Bugs/DispForm.aspx?ID=314&Source=https%3A%2F%2Fgoto%2Enetcompany%2Ecom%2Fcases%2FGTE964%2FFHICORC%2FLists%2FBugs%2FMyDefects%2Easpx&ContentTypeId=0x0108001AE2A0D62F1AD24183A79DF91DF134DD)