### PR TITLE
[Accessibility][Text size] - Settings screen/Navigation header

### DIFF
--- a/FHICORC/Views/Elements/NavigationHeader.xaml.cs
+++ b/FHICORC/Views/Elements/NavigationHeader.xaml.cs
@@ -58,6 +58,7 @@ namespace FHICORC.Views.Elements
             else if (propertyName == CenterLabelTextProperty.PropertyName)
             {
                 CenterLabel.Text = CenterLabelText;
+                UpdateIconsSizesAccessibility();
             }
             else if (propertyName == CenterLabelHeightRequestProperty.PropertyName)
             {
@@ -195,6 +196,35 @@ namespace FHICORC.Views.Elements
         {
             get { return (string)GetValue(RightButtonAccessibilityTextProperty); }
             set { SetValue(RightButtonAccessibilityTextProperty, value); }
+        }
+        private void UpdateIconsSizesAccessibility()
+        {
+            double fontSize = CenterLabel.FontSize;
+            const int threshold = 22;
+            double delta = fontSize - threshold;
+            double scaleValue = 1.0;
+
+            if (Device.RuntimePlatform == Device.iOS && fontSize > threshold)
+            {
+                scaleValue = 1.0 + 0.01 * delta;
+
+            }
+            else if (Device.RuntimePlatform == Device.Android && fontSize > threshold)
+            {
+                scaleValue = 1.0 + 0.015 * delta;
+            }
+
+            if (scaleValue >= 1.4)
+            {
+                scaleValue = 1.4;
+            }
+            else if (scaleValue < 1.0)
+            {
+                scaleValue = 1.0;
+            }
+
+            LeftButton.Scale = scaleValue;
+            RightButton.Scale = scaleValue;
         }
     }
 }

--- a/FHICORC/Views/Menu/SettingsPage.xaml
+++ b/FHICORC/Views/Menu/SettingsPage.xaml
@@ -43,6 +43,7 @@
                             <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
                         <Label
+                            x:Name="LabelSettings"
                             Grid.Row="0"
                             Margin="20,35,20,15"
                             AutomationId="{Binding Strings[SETTINGS_SECTION_1_TITLE_ACC]}"
@@ -210,8 +211,8 @@
                                         <effects:FontSizeLabelEffect/>
                                     </Label.Effects>
                                 </Label>
-
                                 <Switch
+                                    x:Name="SwitchToggledSound"
                                     Grid.Column="1"
                                     Margin="0,0,16,0"
                                     AutomationProperties.IsInAccessibleTree="True"
@@ -242,8 +243,8 @@
                                         <effects:FontSizeLabelEffect/>
                                     </Label.Effects>
                                 </Label>
-
                                 <Switch
+                                    x:Name="SwitchToggledVibration"
                                     Grid.Column="1"
                                     Margin="0,0,16,0"
                                     AutomationProperties.IsInAccessibleTree="True"
@@ -267,8 +268,8 @@
                                     <On Platform="Android" Value="20,50,20,30" />
                                 </OnPlatform>
                             </Grid.Margin>
-
                             <controls:SingleLineButton
+                                x:Name="FetchSingleLineButton"
                                 Grid.Row="0"
                                 Padding="50,0,50,0"
                                 ImageSource="{StaticResource SyncIcon}"

--- a/FHICORC/Views/Menu/SettingsPage.xaml.cs
+++ b/FHICORC/Views/Menu/SettingsPage.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using FHICORC.Configuration;
+using FHICORC.Controls;
 using FHICORC.Services.Interfaces;
 using FHICORC.Utils;
 using FHICORC.ViewModels.Menu;
@@ -13,16 +14,29 @@ namespace FHICORC.Views.Menu
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class SettingsPage : ContentPage
     {
+        private Label _labelSettings;
+        private Switch _switchToggledSound;
+        private Switch _switchToggledVibration;
+        private SingleLineButton _fetchSingleLineButton;
+        private double _fontSize;
+
         public SettingsPage(SettingsPageViewModel viewModel)
         {
             InitializeComponent();
             BindingContext = viewModel;
+            _labelSettings = this.FindByName<Label>("LabelSettings");
+            _switchToggledSound = this.FindByName<Switch>("SwitchToggledSound");
+            _switchToggledVibration = this.FindByName<Switch>("SwitchToggledVibration");
+            _fetchSingleLineButton = this.FindByName<SingleLineButton>("FetchSingleLineButton");
+            _fontSize = _labelSettings.FontSize;
         }
 
         protected override void OnAppearing()
         {
             base.OnAppearing();
             IoCContainer.Resolve<INavigationService>().SetStatusBar(FHICORCColor.NavigationHeaderBackgroundColor.Color(), Color.Black);
+            UpdateIconsSizesAccessibility();
+
         }
 
         void Switch_Toggled_Sound(object sender, ToggledEventArgs e)
@@ -57,6 +71,40 @@ namespace FHICORC.Views.Menu
             {
                 RadioButtonEnglish.IsChecked = true;
             }
+        }
+        private void UpdateIconsSizesAccessibility()
+        {
+            int threshold = 22;
+            double delta = _fontSize - threshold;
+            double scaleValue = 1.0;
+
+            if (Device.RuntimePlatform == Device.iOS && _fontSize > threshold)
+            {
+                scaleValue = 1.0 + 0.01 * delta;
+
+            }
+            else if (Device.RuntimePlatform == Device.Android && _fontSize > threshold)
+            {
+                scaleValue = 1.0 + 0.015 * delta;
+            }
+            
+            if (scaleValue >= 1.4)
+            {
+                scaleValue = 1.4;
+            }
+            else if (scaleValue < 1.0)
+            {
+                scaleValue = 1.0;
+            }
+            double scaleValueButton = scaleValue;
+            if (scaleValueButton >= 1.1)
+            {
+                scaleValueButton = 1.1;
+            }
+            _switchToggledSound.Scale = scaleValue;
+            _switchToggledVibration.Scale = scaleValue;
+            _fetchSingleLineButton.Scale = scaleValueButton;
+
         }
     }
 }


### PR DESCRIPTION
Changes implemented regarding defect 237 Android/iOS:
-Added accessibility sizes for toggle buttons, fetch button and back button on setting screen.
-Added accessibility sizes for header view images.