### PR TITLE
Changed padding on text

### DIFF
--- a/FHICORC/Views/ScannerPages/ScanEuTestResultView.xaml
+++ b/FHICORC/Views/ScannerPages/ScanEuTestResultView.xaml
@@ -144,7 +144,7 @@
                                Text="{Binding TestHeaderValue}" 
                                HorizontalOptions="Start" 
                                VerticalOptions="Center"
-                               Padding="5,0,15,0"
+                               Padding="10,0,20,0"
                                effects:FontSizeLabelEffectParams.MaxFontSize="28.00"
                                effects:FontSizeLabelEffectParams.MinFontSize="15.00">
                             <Label.Effects>


### PR DESCRIPTION
[Text missing on test ceritificate iPhone 12](https://goto.netcompany.com/cases/GTE964/FHICORC/Lists/Bugs/DispForm.aspx?ID=322&Source=https%3A%2F%2Fgoto%2Enetcompany%2Ecom%2Fcases%2FGTE964%2FFHICORC%2FLists%2FBugs%2FAllItems%2Easpx&ContentTypeId=0x0108001AE2A0D62F1AD24183A79DF91DF134DD)


![Screenshot 2021-08-11 at 13 28 42](https://user-images.githubusercontent.com/86463371/129021723-e8014bfb-bc19-4a74-8191-61d663d0fac8.png)
