### PR TITLE
[Bugfix 334] Scan ny button large text

### DIFF
--- a/FHICORC/Views/ScannerPages/ScanEuTestResultView.xaml
+++ b/FHICORC/Views/ScannerPages/ScanEuTestResultView.xaml
@@ -481,7 +481,13 @@
                     Command="{Binding ScanAgainCommand}"
                     ImageSource="{StaticResource ScanRectangle}"
                     Style="{StaticResource CombinedButtonPrimaryStyle}"
-                    Text="{Binding Strings[SCANNER_ERROR_BUTTON_TEXT]}" />
+                    Text="{Binding Strings[SCANNER_ERROR_BUTTON_TEXT]}"
+                    effects:FontSizeLabelEffectParams.MaxFontSize="26.00"
+                    effects:FontSizeLabelEffectParams.MinFontSize="15.00">
+                    <controls:SingleLineButton.Effects>
+                        <effects:FontSizeLabelEffect/>
+                    </controls:SingleLineButton.Effects>
+                </controls:SingleLineButton>
 
                 <!--  Seconds left before the page closes  -->
                 <Label

--- a/FHICORC/Views/ScannerPages/ScanEuVaccineResultView.xaml
+++ b/FHICORC/Views/ScannerPages/ScanEuVaccineResultView.xaml
@@ -435,7 +435,13 @@
                     Command="{Binding ScanAgainCommand}"
                     ImageSource="{StaticResource ScanRectangle}"
                     Style="{StaticResource CombinedButtonPrimaryStyle}"
-                    Text="{Binding Strings[SCANNER_ERROR_BUTTON_TEXT]}" />
+                    Text="{Binding Strings[SCANNER_ERROR_BUTTON_TEXT]}"
+                    effects:FontSizeLabelEffectParams.MaxFontSize="26.00"
+                    effects:FontSizeLabelEffectParams.MinFontSize="15.00">
+                    <controls:SingleLineButton.Effects>
+                        <effects:FontSizeLabelEffect/>
+                    </controls:SingleLineButton.Effects>
+                </controls:SingleLineButton>
 
                 <!--  Seconds left before the page closes  -->
                 <Label


### PR DESCRIPTION
Defect 334: Accessibility - Text size - Skanner: "Scan ny" button shows text too big
- Fixed large text on scan new button on vaccine and test (recovery was already fixed)

Android
![IMG_9165](https://user-images.githubusercontent.com/86482015/144445045-ac39e07e-2934-468d-89c4-afff248cf907.JPG)

iOS
![IMG_9163](https://user-images.githubusercontent.com/86482015/144445039-b71cea95-c798-4f34-b87c-0a5e01785067.PNG)
