### PR TITLE
[Bugfix 331, 332] Screen reader read out name and dob as single letters and numbers

### DIFF
--- a/FHICORC/ViewModels/QrScannerViewModels/ScanEuRecoveryResultViewModel.cs
+++ b/FHICORC/ViewModels/QrScannerViewModels/ScanEuRecoveryResultViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -22,7 +23,6 @@ namespace FHICORC.ViewModels.QrScannerViewModels
     public class ScanEuRecoveryResultViewModel : InfoRecoveryTextViewModel
     {
         private string _fullName;
-        private string _dateOfBirth;
 
         public string FullName
         {
@@ -34,6 +34,18 @@ namespace FHICORC.ViewModels.QrScannerViewModels
             }
         }
 
+        public string _fullNameAccessibilityText;
+        public string FullNameAccessibilityText
+        {
+            get => _fullNameAccessibilityText;
+            set
+            {
+                _fullNameAccessibilityText = value;
+                OnPropertyChanged(nameof(FullNameAccessibilityText));
+            }
+        }
+
+        private string _dateOfBirth;
         public string DateOfBirth
         {
             get => _dateOfBirth;
@@ -41,6 +53,17 @@ namespace FHICORC.ViewModels.QrScannerViewModels
             {
                 _dateOfBirth = value;
                 OnPropertyChanged(nameof(DateOfBirth));
+            }
+        }
+
+        private string _dateOfBirthAccessibilityText;
+        public string DateOfBirthAccessibilityText
+        {
+            get => _dateOfBirthAccessibilityText;
+            set
+            {
+                _dateOfBirthAccessibilityText = value;
+                OnPropertyChanged(nameof(DateOfBirthAccessibilityText));
             }
         }
 
@@ -166,7 +189,10 @@ namespace FHICORC.ViewModels.QrScannerViewModels
                     if (tokenValidateResultModel.DecodedModel is Core.Services.Model.EuDCCModel._1._3._0.DCCPayload cwt)
                     {
                         FullName = cwt.DCCPayloadData.DCC.PersonName.FullName;
+                        FullNameAccessibilityText = cwt.DCCPayloadData.DCC.PersonName.FullName.ToLower();
                         DateOfBirth = cwt.DCCPayloadData.DCC.DateOfBirth;
+                        var dateOfBirthAccessibility = DateTime.ParseExact(DateOfBirth, "yyyy-MM-dd", CultureInfo.InvariantCulture);
+                        DateOfBirthAccessibilityText = String.Format("{0:dd. MMMM yyyy}", dateOfBirthAccessibility);
                         PassportViewModel.PassportData = new PassportData(string.Empty, cwt);
                         RulesFeedbackViewModel = new RulesFeedbackViewModel(tokenValidateResultModel.RulesFeedBacks);
                         RulesEnginePassed = RulesFeedbackViewModel.RulesEngineResult.Where(x => x.Result == RulesFeedbackResult.TRUE).Count();

--- a/FHICORC/ViewModels/QrScannerViewModels/ScanEuTestResultViewModel.cs
+++ b/FHICORC/ViewModels/QrScannerViewModels/ScanEuTestResultViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -22,8 +23,6 @@ namespace FHICORC.ViewModels.QrScannerViewModels
     public class ScanEuTestResultViewModel : InfoTestTextViewModel
     {
         private string _fullName;
-        private string _dateOfBirth;
-
         public string FullName
         {
             get => _fullName;
@@ -34,6 +33,18 @@ namespace FHICORC.ViewModels.QrScannerViewModels
             }
         }
 
+        public string _fullNameAccessibilityText;
+        public string FullNameAccessibilityText
+        {
+            get => _fullNameAccessibilityText;
+            set
+            {
+                _fullNameAccessibilityText = value;
+                OnPropertyChanged(nameof(FullNameAccessibilityText));
+            }
+        }
+
+        private string _dateOfBirth;
         public string DateOfBirth
         {
             get => _dateOfBirth;
@@ -41,6 +52,17 @@ namespace FHICORC.ViewModels.QrScannerViewModels
             {
                 _dateOfBirth = value;
                 OnPropertyChanged(nameof(DateOfBirth));
+            }
+        }
+
+        private string _dateOfBirthAccessibilityText;
+        public string DateOfBirthAccessibilityText
+        {
+            get => _dateOfBirthAccessibilityText;
+            set
+            {
+                _dateOfBirthAccessibilityText = value;
+                OnPropertyChanged(nameof(DateOfBirthAccessibilityText));
             }
         }
 
@@ -168,7 +190,10 @@ namespace FHICORC.ViewModels.QrScannerViewModels
                     if (tokenValidateResultModel.DecodedModel is Core.Services.Model.EuDCCModel._1._3._0.DCCPayload cwt)
                     {
                         FullName = cwt.DCCPayloadData.DCC.PersonName.FullName;
+                        FullNameAccessibilityText = cwt.DCCPayloadData.DCC.PersonName.FullName.ToLower();
                         DateOfBirth = cwt.DCCPayloadData.DCC.DateOfBirth;
+                        var dateOfBirthAccessibility = DateTime.ParseExact(DateOfBirth, "yyyy-MM-dd", CultureInfo.InvariantCulture);
+                        DateOfBirthAccessibilityText = String.Format("{0:dd. MMMM yyyy}", dateOfBirthAccessibility);
                         PassportViewModel.PassportData = new PassportData(string.Empty, cwt);
                         RulesFeedbackViewModel = new RulesFeedbackViewModel(tokenValidateResultModel.RulesFeedBacks);
                         RulesEnginePassed = RulesFeedbackViewModel.RulesEngineResult.Where(x => x.Result == RulesFeedbackResult.TRUE).Count();

--- a/FHICORC/ViewModels/QrScannerViewModels/ScanEuVaccineResultViewModel.cs
+++ b/FHICORC/ViewModels/QrScannerViewModels/ScanEuVaccineResultViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -22,8 +23,6 @@ namespace FHICORC.ViewModels.QrScannerViewModels
     public class ScanEuVaccineResultViewModel : InfoVaccineTextViewModel
     {
         private string _fullName;
-        private string _dateOfBirth;
-
         public string FullName
         {
             get => _fullName;
@@ -34,6 +33,18 @@ namespace FHICORC.ViewModels.QrScannerViewModels
             }
         }
 
+        public string _fullNameAccessibilityText;
+        public string FullNameAccessibilityText
+        {
+            get => _fullNameAccessibilityText;
+            set
+            {
+                _fullNameAccessibilityText = value;
+                OnPropertyChanged(nameof(FullNameAccessibilityText));
+            }
+        }
+
+        private string _dateOfBirth;
         public string DateOfBirth
         {
             get => _dateOfBirth;
@@ -41,6 +52,17 @@ namespace FHICORC.ViewModels.QrScannerViewModels
             {
                 _dateOfBirth = value;
                 OnPropertyChanged(nameof(DateOfBirth));
+            }
+        }
+
+        private string _dateOfBirthAccessibilityText;
+        public string DateOfBirthAccessibilityText
+        {
+            get => _dateOfBirthAccessibilityText;
+            set
+            {
+                _dateOfBirthAccessibilityText = value;
+                OnPropertyChanged(nameof(DateOfBirthAccessibilityText));
             }
         }
 
@@ -166,7 +188,10 @@ namespace FHICORC.ViewModels.QrScannerViewModels
                     if (tokenValidateResultModel.DecodedModel is Core.Services.Model.EuDCCModel._1._3._0.DCCPayload cwt)
                     {
                         FullName = cwt.DCCPayloadData.DCC.PersonName.FullName;
+                        FullNameAccessibilityText = cwt.DCCPayloadData.DCC.PersonName.FullName.ToLower();
                         DateOfBirth = cwt.DCCPayloadData.DCC.DateOfBirth;
+                        var dateOfBirthAccessibility = DateTime.ParseExact(DateOfBirth, "yyyy-MM-dd", CultureInfo.InvariantCulture);
+                        DateOfBirthAccessibilityText = String.Format("{0:dd. MMMM yyyy}", dateOfBirthAccessibility);
                         PassportViewModel.PassportData = new PassportData(string.Empty, cwt);
                         RulesFeedbackViewModel = new RulesFeedbackViewModel(tokenValidateResultModel.RulesFeedBacks);
                         RulesEnginePassed = RulesFeedbackViewModel.RulesEngineResult.Where(x => x.Result == RulesFeedbackResult.TRUE).Count();

--- a/FHICORC/Views/ScannerPages/ScanEuRecoveryResultView.xaml
+++ b/FHICORC/Views/ScannerPages/ScanEuRecoveryResultView.xaml
@@ -71,7 +71,8 @@
                                      Spacing="6"
                                      Padding="0"
                                      Margin="0, 30">
-                            <Label Text="{Binding FullName}"
+                            <Label AutomationId="{Binding FullNameAccessibilityText}"
+                                   Text="{Binding FullName}"
                                    AutomationProperties.IsInAccessibleTree="True"
                                    Style="{StaticResource ContentTitleStyle}"
                                    HorizontalTextAlignment="Center"
@@ -82,7 +83,8 @@
                                     <effects:FontSizeLabelEffect/>
                                 </Label.Effects>
                             </Label>
-                            <Label Text="{Binding DateOfBirth}"
+                            <Label AutomationProperties.Name="{Binding DateOfBirthAccessibilityText}"
+                                   Text="{Binding DateOfBirth}"
                                    Style="{StaticResource ContentStyle}"
                                    HorizontalTextAlignment="Center"
                                    HorizontalOptions="Center"

--- a/FHICORC/Views/ScannerPages/ScanEuTestResultView.xaml
+++ b/FHICORC/Views/ScannerPages/ScanEuTestResultView.xaml
@@ -72,7 +72,8 @@
                                      Spacing="6"
                                      Padding="0"
                                      Margin="0, 30">
-                            <Label Text="{Binding FullName}"
+                            <Label AutomationId="{Binding FullNameAccessibilityText}"
+                                   Text="{Binding FullName}"
                                    AutomationProperties.IsInAccessibleTree="True"
                                    Style="{StaticResource ContentTitleStyle}"
                                    HorizontalTextAlignment="Center"
@@ -83,7 +84,8 @@
                                     <effects:FontSizeLabelEffect/>
                                 </Label.Effects>
                             </Label>
-                            <Label Text="{Binding DateOfBirth}"
+                            <Label AutomationProperties.Name="{Binding DateOfBirthAccessibilityText}"
+                                   Text="{Binding DateOfBirth}"
                                    Style="{StaticResource ContentStyle}"
                                    HorizontalTextAlignment="Center"
                                    HorizontalOptions="Center"

--- a/FHICORC/Views/ScannerPages/ScanEuVaccineResultView.xaml
+++ b/FHICORC/Views/ScannerPages/ScanEuVaccineResultView.xaml
@@ -72,7 +72,8 @@
                                      Spacing="6"
                                      Padding="0"
                                      Margin="0, 30">
-                            <Label Text="{Binding FullName}"
+                            <Label AutomationId="{Binding FullNameAccessibilityText}"
+                                   Text="{Binding FullName}"
                                    AutomationProperties.IsInAccessibleTree="True"
                                    Style="{StaticResource ContentTitleStyle}"
                                    HorizontalTextAlignment="Center"
@@ -83,7 +84,8 @@
                                     <effects:FontSizeLabelEffect/>
                                 </Label.Effects>
                             </Label>
-                            <Label Text="{Binding DateOfBirth}"
+                            <Label AutomationProperties.Name="{Binding DateOfBirthAccessibilityText}"
+                                   Text="{Binding DateOfBirth}"
                                    Style="{StaticResource ContentStyle}"
                                    HorizontalTextAlignment="Center"
                                    HorizontalOptions="Center"


### PR DESCRIPTION
Defect 331: Accessibility - Screen reader: Scanner: Border/Domestic control - Name read out aloud as single letters
Defect 332: Accessibility - Screen reader: Scanner: Border/Domestic control - birthdate read out aloud as single numbers
- Screen reader now reads out name instead of single letters on Android
- Screen reader now reads out date of birth as a date and not single numbers on iOS