### PR TITLE
[Bugfix 335] Text too big for green line large text

### DIFF
--- a/FHICORC/Views/Elements/ScanSuccessResultPopup.xaml
+++ b/FHICORC/Views/Elements/ScanSuccessResultPopup.xaml
@@ -115,16 +115,16 @@
 
             <StackLayout
                 Grid.Row="3"
-                HeightRequest="41"
                 BackgroundColor="{StaticResource SuccessBorderColor}"
                 Margin="0, 30, 0, 0"
-                Padding="0, 2">
+                Padding="0, 2"
+                Spacing="0">
                 <Label Text="{Binding SuccessBannerText}"
                        Style="{StaticResource SubtitleStyle}"
                        TextColor="{StaticResource FHIPrimaryBlue}"
                        LineBreakMode="NoWrap"
                        MaxLines="1"
-                       Margin="0,8,0,0"
+                       Padding="0, 10"
                        FontSize="17"
                        VerticalTextAlignment="Center"
                        VerticalOptions="Center"


### PR DESCRIPTION
Defect 335: Accessibility -Text Size: Text bigger than the green label line for valid code
- Fixed text bigger than green line when large text is on, on Android

![262913785_591146475445414_2818431861070045903_n](https://user-images.githubusercontent.com/86482015/144605110-79c6fc09-5fac-4be0-96e0-5665c4d5145f.jpg)


