### PR TITLE
[Bugfix 332] Screen reader birth date Android

### DIFF
--- a/FHICORC/Views/ScannerPages/ScanEuRecoveryResultView.xaml
+++ b/FHICORC/Views/ScannerPages/ScanEuRecoveryResultView.xaml
@@ -83,7 +83,8 @@
                                     <effects:FontSizeLabelEffect/>
                                 </Label.Effects>
                             </Label>
-                            <Label AutomationProperties.Name="{Binding DateOfBirthAccessibilityText}"
+                            <Label x:Name="DateOfBirthLabel"
+                                   AutomationId="{Binding DateOfBirthAccessibilityText}"
                                    Text="{Binding DateOfBirth}"
                                    Style="{StaticResource ContentStyle}"
                                    HorizontalTextAlignment="Center"

--- a/FHICORC/Views/ScannerPages/ScanEuRecoveryResultView.xaml.cs
+++ b/FHICORC/Views/ScannerPages/ScanEuRecoveryResultView.xaml.cs
@@ -29,6 +29,19 @@ namespace FHICORC.Views.ScannerPages
         {
             ((ScanEuRecoveryResultViewModel)BindingContext).Timer.Enabled = true;
             base.OnAppearing();
+            SetAccessibilityText();
+        }
+
+        private void SetAccessibilityText()
+        {
+            if (Device.RuntimePlatform == Device.iOS)
+            {
+                AutomationProperties.SetName(DateOfBirthLabel, ((ScanEuRecoveryResultViewModel)BindingContext).DateOfBirthAccessibilityText);
+            }
+            else
+            {
+                AutomationProperties.SetName(DateOfBirthLabel, "");
+            }
         }
     }
 }

--- a/FHICORC/Views/ScannerPages/ScanEuTestResultView.xaml
+++ b/FHICORC/Views/ScannerPages/ScanEuTestResultView.xaml
@@ -84,7 +84,8 @@
                                     <effects:FontSizeLabelEffect/>
                                 </Label.Effects>
                             </Label>
-                            <Label AutomationProperties.Name="{Binding DateOfBirthAccessibilityText}"
+                            <Label x:Name="DateOfBirthLabel"
+                                   AutomationId="{Binding DateOfBirthAccessibilityText}"
                                    Text="{Binding DateOfBirth}"
                                    Style="{StaticResource ContentStyle}"
                                    HorizontalTextAlignment="Center"

--- a/FHICORC/Views/ScannerPages/ScanEuTestResultView.xaml.cs
+++ b/FHICORC/Views/ScannerPages/ScanEuTestResultView.xaml.cs
@@ -29,6 +29,19 @@ namespace FHICORC.Views.ScannerPages
         {
             ((ScanEuTestResultViewModel)BindingContext).Timer.Enabled = true;
             base.OnAppearing();
+            SetAccessibilityText();
+        }
+
+        private void SetAccessibilityText()
+        {
+            if (Device.RuntimePlatform == Device.iOS)
+            {
+                AutomationProperties.SetName(DateOfBirthLabel, ((ScanEuTestResultViewModel)BindingContext).DateOfBirthAccessibilityText);
+            }
+            else
+            {
+                AutomationProperties.SetName(DateOfBirthLabel, "");
+            }
         }
     }
 }

--- a/FHICORC/Views/ScannerPages/ScanEuVaccineResultView.xaml
+++ b/FHICORC/Views/ScannerPages/ScanEuVaccineResultView.xaml
@@ -84,7 +84,8 @@
                                     <effects:FontSizeLabelEffect/>
                                 </Label.Effects>
                             </Label>
-                            <Label AutomationProperties.Name="{Binding DateOfBirthAccessibilityText}"
+                            <Label x:Name="DateOfBirthLabel"
+                                   AutomationId="{Binding DateOfBirthAccessibilityText}"
                                    Text="{Binding DateOfBirth}"
                                    Style="{StaticResource ContentStyle}"
                                    HorizontalTextAlignment="Center"

--- a/FHICORC/Views/ScannerPages/ScanEuVaccineResultView.xaml.cs
+++ b/FHICORC/Views/ScannerPages/ScanEuVaccineResultView.xaml.cs
@@ -29,6 +29,19 @@ namespace FHICORC.Views.ScannerPages
         {
             ((ScanEuVaccineResultViewModel)BindingContext).Timer.Enabled = true;
             base.OnAppearing();
+            SetAccessibilityText();
+        }
+
+        private void SetAccessibilityText()
+        {
+            if (Device.RuntimePlatform == Device.iOS)
+            {
+                AutomationProperties.SetName(DateOfBirthLabel, ((ScanEuVaccineResultViewModel)BindingContext).DateOfBirthAccessibilityText);
+            }
+            else
+            {
+                AutomationProperties.SetName(DateOfBirthLabel, "");
+            }
         }
     }
 }


### PR DESCRIPTION
Defect 332: Accessibility - Screen reader: Scanner: Border/Domestic control - birthdate read out aloud as single numbers
- Update so that screen reader uses AutomationId for birthdate on Android and Name for birthdate on iOS
- Birth date is no longer read out twice on Android 
- Tested on iOS and two different Android devices