### PR TITLE
[Bugfix 337] Accessibility screen reader vaccination and recovery date

### DIFF
--- a/FHICORC/ViewModels/Certificates/InfoRecoveryTextViewModel.cs
+++ b/FHICORC/ViewModels/Certificates/InfoRecoveryTextViewModel.cs
@@ -100,8 +100,15 @@ namespace FHICORC.ViewModels.Certificates
 
         public void SetAccessibilityTextDate()
         {
-            var recoveryFirstPositiveDate = DateTime.ParseExact(RecoveryDateValue, "yyyy-MM-dd", CultureInfo.InvariantCulture);
-            RecoveryDateFirstPositiveAccessibilityText = string.Format("{0:dd. MMMM yyyy}", recoveryFirstPositiveDate);
+            try
+            {
+                var recoveryFirstPositiveDate = DateTime.ParseExact(RecoveryDateValue, "yyyy-MM-dd", CultureInfo.InvariantCulture);
+                RecoveryDateFirstPositiveAccessibilityText = string.Format("{0:dd. MMMM yyyy}", recoveryFirstPositiveDate);
+            }
+            catch (FormatException)
+            {
+
+            }
         }
     }
 }

--- a/FHICORC/ViewModels/Certificates/InfoRecoveryTextViewModel.cs
+++ b/FHICORC/ViewModels/Certificates/InfoRecoveryTextViewModel.cs
@@ -107,7 +107,7 @@ namespace FHICORC.ViewModels.Certificates
             }
             catch (FormatException)
             {
-
+                RecoveryDateFirstPositiveAccessibilityText = RecoveryDateValue;
             }
         }
     }

--- a/FHICORC/ViewModels/Certificates/InfoRecoveryTextViewModel.cs
+++ b/FHICORC/ViewModels/Certificates/InfoRecoveryTextViewModel.cs
@@ -1,4 +1,6 @@
-﻿using FHICORC.Core.Services.Interface;
+﻿using System;
+using System.Globalization;
+using FHICORC.Core.Services.Interface;
 using FHICORC.Core.Services.Model.Converter;
 using FHICORC.Core.Services.Model.EuDCCModel.ValueSet;
 using FHICORC.Services;
@@ -58,6 +60,7 @@ namespace FHICORC.ViewModels.Certificates
         public bool ShowCertificate { get; set; } = true;
         public bool ShowHeader { get; set; }
         public bool ShowTextInEnglish { get; set; }
+        public string RecoveryDateFirstPositiveAccessibilityText { get; set; }
 
         private IDgcValueSetTranslator _translator;
 
@@ -87,12 +90,18 @@ namespace FHICORC.ViewModels.Certificates
                 OnPropertyChanged(nameof(RecoveryIdentifierValue));
                 OnPropertyChanged(nameof(RecoveryValidFromValueAccessibility));
                 OnPropertyChanged(nameof(RecoveryValidToValueAccessibility));
+                OnPropertyChanged(nameof(RecoveryDateFirstPositiveAccessibilityText));
             }
             if (ShowHeader)
             {
                 OnPropertyChanged(nameof(RecoveryHeaderValue));
             }
+        }
 
+        public void SetAccessibilityTextDate()
+        {
+            var recoveryFirstPositiveDate = DateTime.ParseExact(RecoveryDateValue, "yyyy-MM-dd", CultureInfo.InvariantCulture);
+            RecoveryDateFirstPositiveAccessibilityText = string.Format("{0:dd. MMMM yyyy}", recoveryFirstPositiveDate);
         }
     }
 }

--- a/FHICORC/ViewModels/Certificates/InfoVaccineTextViewModel.cs
+++ b/FHICORC/ViewModels/Certificates/InfoVaccineTextViewModel.cs
@@ -1,4 +1,6 @@
-﻿using FHICORC.Core.Services.Interface;
+﻿using System;
+using System.Globalization;
+using FHICORC.Core.Services.Interface;
 using FHICORC.Core.Services.Model.Converter;
 using FHICORC.Core.Services.Model.EuDCCModel.ValueSet;
 using FHICORC.Services;
@@ -69,6 +71,7 @@ namespace FHICORC.ViewModels.Certificates
         public bool ShowCertificate { get; set; } = true;
         public bool ShowHeader { get; set; }
         public bool ShowTextInEnglish { get; set; }
+        public string VaccineVaccinationDateValueAccessibilityText { get; set; }
 
         private IDgcValueSetTranslator _translator;
 
@@ -92,6 +95,7 @@ namespace FHICORC.ViewModels.Certificates
             OnPropertyChanged(nameof(VaccineVaccinationCountryValue));
             OnPropertyChanged(nameof(VaccineVaccinationDateValue));
             OnPropertyChanged(nameof(VaccineTargetDisease));
+            OnPropertyChanged(nameof(VaccineVaccinationDateValueAccessibilityText));
 
             if (ShowCertificate)
             {
@@ -104,6 +108,12 @@ namespace FHICORC.ViewModels.Certificates
                 OnPropertyChanged(nameof(VaccineHeaderValue));
             }
 
+        }
+
+        public void SetAccessibilityTextDate()
+        {
+            var vaccinationDate = DateTime.ParseExact(VaccineVaccinationDateValue, "yyyy-MM-dd", CultureInfo.InvariantCulture);
+            VaccineVaccinationDateValueAccessibilityText = string.Format("{0:dd. MMMM yyyy}", vaccinationDate);
         }
     }
 }

--- a/FHICORC/ViewModels/Certificates/InfoVaccineTextViewModel.cs
+++ b/FHICORC/ViewModels/Certificates/InfoVaccineTextViewModel.cs
@@ -112,8 +112,15 @@ namespace FHICORC.ViewModels.Certificates
 
         public void SetAccessibilityTextDate()
         {
-            var vaccinationDate = DateTime.ParseExact(VaccineVaccinationDateValue, "yyyy-MM-dd", CultureInfo.InvariantCulture);
-            VaccineVaccinationDateValueAccessibilityText = string.Format("{0:dd. MMMM yyyy}", vaccinationDate);
+            try
+            {
+                var vaccinationDate = DateTime.ParseExact(VaccineVaccinationDateValue, "yyyy-MM-dd", CultureInfo.InvariantCulture);
+                VaccineVaccinationDateValueAccessibilityText = string.Format("{0:dd. MMMM yyyy}", vaccinationDate);
+            }
+            catch (FormatException)
+            {
+
+            }
         }
     }
 }

--- a/FHICORC/ViewModels/Certificates/InfoVaccineTextViewModel.cs
+++ b/FHICORC/ViewModels/Certificates/InfoVaccineTextViewModel.cs
@@ -119,7 +119,7 @@ namespace FHICORC.ViewModels.Certificates
             }
             catch (FormatException)
             {
-
+                VaccineVaccinationDateValueAccessibilityText = VaccineVaccinationDateValue;
             }
         }
     }

--- a/FHICORC/ViewModels/QrScannerViewModels/ScanEuRecoveryResultViewModel.cs
+++ b/FHICORC/ViewModels/QrScannerViewModels/ScanEuRecoveryResultViewModel.cs
@@ -201,6 +201,7 @@ namespace FHICORC.ViewModels.QrScannerViewModels
                         NumberOfRulesFulfilledAccessibilityText = string.Format("RULES_ENGINE_FULFILLED_COUNT_ACCESSIBILITY_TEXT".Translate(), RulesEnginePassed, RulesEngineResultCount);
                         UpdateRuleColorAndText();
                         UpdateView();
+                        SetAccessibilityTextDate();
                     }
                 }
             }

--- a/FHICORC/ViewModels/QrScannerViewModels/ScanEuVaccineResultViewModel.cs
+++ b/FHICORC/ViewModels/QrScannerViewModels/ScanEuVaccineResultViewModel.cs
@@ -200,6 +200,7 @@ namespace FHICORC.ViewModels.QrScannerViewModels
                         NumberOfRulesFulfilledAccessibilityText = string.Format("RULES_ENGINE_FULFILLED_COUNT_ACCESSIBILITY_TEXT".Translate(), RulesEnginePassed, RulesEngineResultCount);
                         UpdateRuleColorAndText();
                         UpdateView();
+                        SetAccessibilityTextDate();
                     }
                 }
             }

--- a/FHICORC/Views/ScannerPages/ScanEuRecoveryResultView.xaml
+++ b/FHICORC/Views/ScannerPages/ScanEuRecoveryResultView.xaml
@@ -219,7 +219,9 @@
                                 <effects:FontSizeLabelEffect/>
                             </Label.Effects>
                         </Label>
-                        <Label Grid.Row="4" Grid.Column="0" 
+                        <Label Grid.Row="4" Grid.Column="0"
+                               x:Name="RecoveryDateFirstPositive"
+                               AutomationId="{Binding RecoveryDateFirstPositiveAccessibilityText}"
                                Text="{Binding RecoveryDateValue}"
                                Style="{StaticResource InfoPaneItemValue}" HorizontalOptions="Start"
                                effects:FontSizeLabelEffectParams.MaxFontSize="26.00"

--- a/FHICORC/Views/ScannerPages/ScanEuRecoveryResultView.xaml.cs
+++ b/FHICORC/Views/ScannerPages/ScanEuRecoveryResultView.xaml.cs
@@ -37,10 +37,12 @@ namespace FHICORC.Views.ScannerPages
             if (Device.RuntimePlatform == Device.iOS)
             {
                 AutomationProperties.SetName(DateOfBirthLabel, ((ScanEuRecoveryResultViewModel)BindingContext).DateOfBirthAccessibilityText);
+                AutomationProperties.SetName(RecoveryDateFirstPositive, ((ScanEuRecoveryResultViewModel)BindingContext).RecoveryDateFirstPositiveAccessibilityText);
             }
             else
             {
                 AutomationProperties.SetName(DateOfBirthLabel, "");
+                AutomationProperties.SetName(RecoveryDateFirstPositive, "");
             }
         }
     }

--- a/FHICORC/Views/ScannerPages/ScanEuVaccineResultView.xaml
+++ b/FHICORC/Views/ScannerPages/ScanEuVaccineResultView.xaml
@@ -202,7 +202,9 @@
                                 <effects:FontSizeLabelEffect/>
                             </Label.Effects>
                         </Label>
-                        <Label Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" 
+                        <Label Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
+                               x:Name="VaccineVaccinationDate"
+                               AutomationId="{Binding VaccineVaccinationDateValueAccessibilityText}"
                                Text="{Binding VaccineVaccinationDateValue}" 
                                Style="{StaticResource InfoPaneItemValue}" 
                                HorizontalOptions="Start"

--- a/FHICORC/Views/ScannerPages/ScanEuVaccineResultView.xaml.cs
+++ b/FHICORC/Views/ScannerPages/ScanEuVaccineResultView.xaml.cs
@@ -37,10 +37,12 @@ namespace FHICORC.Views.ScannerPages
             if (Device.RuntimePlatform == Device.iOS)
             {
                 AutomationProperties.SetName(DateOfBirthLabel, ((ScanEuVaccineResultViewModel)BindingContext).DateOfBirthAccessibilityText);
+                AutomationProperties.SetName(VaccineVaccinationDate, ((ScanEuVaccineResultViewModel)BindingContext).VaccineVaccinationDateValueAccessibilityText);
             }
             else
             {
                 AutomationProperties.SetName(DateOfBirthLabel, "");
+                AutomationProperties.SetName(VaccineVaccinationDate, "");
             }
         }
     }


### PR DESCRIPTION
Defect 337: Accessibility - Screen reader: Test- and vaccinations date is not read out aloud correct
- Date of first positive test for recovery and date of vaccination is read out as dates and not numbers
- Tested on iOS and Android