### PR TITLE
Handle given name in smart health card with empty array or null.

### DIFF
--- a/FHICORC.Core/Services/Model/SmartHealthCardModel/Shc/SmartHealthCardPersonName.cs
+++ b/FHICORC.Core/Services/Model/SmartHealthCardModel/Shc/SmartHealthCardPersonName.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace FHICORC.Core.Services.Model.SmartHealthCardModel.Shc
 {
@@ -12,6 +10,7 @@ namespace FHICORC.Core.Services.Model.SmartHealthCardModel.Shc
         [JsonProperty("given")]
         public string[] GivenName { get; set; }
 
-        public string FullName => $"{FamilyName}, {string.Join(" ", GivenName)}";
+        public string FullName => FamilyName
+            + (GivenName != null && GivenName.Length != 0 ? $", {string.Join(" ", GivenName)}" : "");
     }
 }

--- a/FHICORC.Tests/ModelTests/SmartHealthCardPersonNameTests.cs
+++ b/FHICORC.Tests/ModelTests/SmartHealthCardPersonNameTests.cs
@@ -1,0 +1,20 @@
+﻿using FHICORC.Core.Services.Model.SmartHealthCardModel.Shc;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace FHICORC.Tests.ModelTests
+{
+    public class SmartHealthCardPersonNameTests
+    {
+        [TestCase("Anyperson, John B.", "{\"family\":\"Anyperson\",\"given\":[\"John\",\"B.\"]}")]
+        [TestCase("Anyperson, John", "{\"family\":\"Anyperson\",\"given\":[\"John\"]}")]
+        [TestCase("Anyperson", "{\"family\":\"Anyperson\",\"given\":[]}")]
+        [TestCase("Anyperson", "{\"family\":\"Anyperson\"}")]
+        public void FullName_HandlesDifferentData(string expected, string json)
+        {
+            SmartHealthCardPersonName personName = JsonConvert.DeserializeObject<SmartHealthCardPersonName>(json);
+
+            Assert.AreEqual(expected, personName.FullName);
+        }
+    }
+}


### PR DESCRIPTION
Minor change so empty array gives "Lastname" instead of "Lastname, " and null value does not throw exception.