### PR TITLE
Defect 340: name and dob not in line when scanning NO certificate

### DIFF
--- a/FHICORC/Views/Elements/ScanSuccessResultPopup.xaml
+++ b/FHICORC/Views/Elements/ScanSuccessResultPopup.xaml
@@ -94,7 +94,8 @@
                        VerticalOptions="Center"
                        VerticalTextAlignment="Start"
                        effects:FontSizeLabelEffectParams.MaxFontSize="24.00"
-                       effects:FontSizeLabelEffectParams.MinFontSize="12.00">
+                       effects:FontSizeLabelEffectParams.MinFontSize="12.00"
+                       LineHeight="1.2">
                     <Label.Effects>
                         <effects:FontSizeLabelEffect/>
                     </Label.Effects>


### PR DESCRIPTION
- Added line height to text so that name and date of birth is on same line on iOS

iOS
![IMG_9399](https://user-images.githubusercontent.com/86482015/153144126-d61dda52-aad0-4552-ba83-c84ed6a06cb9.PNG)

Android
![IMG_9400](https://user-images.githubusercontent.com/86482015/153144145-d058afdb-adbb-40ba-a127-4675bb28f208.JPG)

