### PR TITLE
Define columns in navigation header, so elements dont overlap each other with long text.

### DIFF
--- a/FHICORC/ViewModels/QrScannerViewModels/ScanEuTestResultViewModel.cs
+++ b/FHICORC/ViewModels/QrScannerViewModels/ScanEuTestResultViewModel.cs
@@ -8,7 +8,6 @@ using FHICORC.Core.Data;
 using FHICORC.Core.Services.Enum;
 using FHICORC.Core.Services.Interface;
 using FHICORC.Core.Services.Model;
-using FHICORC.Core.Services.Model.BusinessRules;
 using FHICORC.Data;
 using FHICORC.Enums;
 using FHICORC.Models;

--- a/FHICORC/ViewModels/QrScannerViewModels/ScanEuVaccineResultViewModel.cs
+++ b/FHICORC/ViewModels/QrScannerViewModels/ScanEuVaccineResultViewModel.cs
@@ -8,7 +8,6 @@ using FHICORC.Core.Data;
 using FHICORC.Core.Services.Enum;
 using FHICORC.Core.Services.Interface;
 using FHICORC.Core.Services.Model;
-using FHICORC.Core.Services.Model.BusinessRules;
 using FHICORC.Data;
 using FHICORC.Enums;
 using FHICORC.Models;

--- a/FHICORC/Views/Elements/NavigationHeader.xaml
+++ b/FHICORC/Views/Elements/NavigationHeader.xaml
@@ -8,26 +8,29 @@
     x:Name="HeaderGrid"
     BackgroundColor="{StaticResource NavigationHeaderBackgroundColor}">
 
-    <Grid Margin="10,10"
-          ColumnSpacing="10"
-          ColumnDefinitions="Auto, *, Auto">
+    <StackLayout Margin="10"
+                 Spacing="6"
+                 Orientation="Horizontal"
+                 HorizontalOptions="FillAndExpand">
         <ImageButton
             x:Name="LeftButton"
-            Grid.Column="0"
-            Padding="6,6,6,6"
+            Padding="6"
+            WidthRequest="40"
+            MinimumWidthRequest="40"
             AutomationId="LeftButton"
             BackgroundColor="Transparent"
             HorizontalOptions="Start"
             VerticalOptions="Center" />
+
         <Label
             x:Name="CenterLabel"
-            Grid.Column="1"
             local:FontSizeLabelEffectParams.MaxFontSize="32"
             local:FontSizeLabelEffectParams.MinFontSize="12"
             AutomationId="{Binding CenterLabelText}"
             HorizontalOptions="CenterAndExpand"
             HorizontalTextAlignment="Center"
-            LineBreakMode="TailTruncation"
+            LineBreakMode="WordWrap"
+            MaxLines="2"
             Style="{StaticResource NavigationTitleTextStyle}"
             Text="{Binding CenterLabelText}"
             VerticalOptions="Center"
@@ -36,13 +39,15 @@
                 <local:FontSizeLabelEffect />
             </Label.Effects>
         </Label>
+
         <ImageButton
             x:Name="RightButton"
-            Grid.Column="2"
-            Padding="10,0,10,0"
+            Padding="6"
+            WidthRequest="40"
+            MinimumWidthRequest="40"
             AutomationId="RightButton"
             BackgroundColor="Transparent"
             HorizontalOptions="End"
             VerticalOptions="Center"/>
-    </Grid>
+    </StackLayout>
 </Grid>

--- a/FHICORC/Views/Elements/NavigationHeader.xaml
+++ b/FHICORC/Views/Elements/NavigationHeader.xaml
@@ -8,23 +8,26 @@
     x:Name="HeaderGrid"
     BackgroundColor="{StaticResource NavigationHeaderBackgroundColor}">
 
-    <Grid Margin="10,10">
+    <Grid Margin="10,10"
+          ColumnSpacing="10"
+          ColumnDefinitions="Auto, *, Auto">
         <ImageButton
             x:Name="LeftButton"
+            Grid.Column="0"
             Padding="6,6,6,6"
             AutomationId="LeftButton"
             BackgroundColor="Transparent"
             HorizontalOptions="Start"
             VerticalOptions="Center" />
-
         <Label
             x:Name="CenterLabel"
+            Grid.Column="1"
             local:FontSizeLabelEffectParams.MaxFontSize="32"
             local:FontSizeLabelEffectParams.MinFontSize="12"
             AutomationId="{Binding CenterLabelText}"
             HorizontalOptions="CenterAndExpand"
             HorizontalTextAlignment="Center"
-            LineBreakMode="NoWrap"
+            LineBreakMode="TailTruncation"
             Style="{StaticResource NavigationTitleTextStyle}"
             Text="{Binding CenterLabelText}"
             VerticalOptions="Center"
@@ -33,9 +36,9 @@
                 <local:FontSizeLabelEffect />
             </Label.Effects>
         </Label>
-
         <ImageButton
             x:Name="RightButton"
+            Grid.Column="2"
             Padding="10,0,10,0"
             AutomationId="RightButton"
             BackgroundColor="Transparent"

--- a/FHICORC/Views/Elements/NavigationHeader.xaml.cs
+++ b/FHICORC/Views/Elements/NavigationHeader.xaml.cs
@@ -13,12 +13,10 @@ namespace FHICORC.Views.Elements
         {
             InitializeComponent();
             HeaderBackgroundColour = FHICORCColor.NavigationHeaderBackgroundColor.Color();
-            LeftButtonHeightRequest = 30;
-            CenterLabelHeightRequest = 40;
-            RightButtonHeightRequest = 30;
+            LeftButtonHeightRequest = 40;
+            RightButtonHeightRequest = 40;
 
             CenterLabel.Text = "LANDING_PAGE_TITLE".Translate();
-
 
             AutomationProperties.SetIsInAccessibleTree(CenterLabel, true);
             AutomationProperties.SetIsInAccessibleTree(LeftButton, false);
@@ -59,10 +57,6 @@ namespace FHICORC.Views.Elements
             {
                 CenterLabel.Text = CenterLabelText;
                 UpdateIconsSizesAccessibility();
-            }
-            else if (propertyName == CenterLabelHeightRequestProperty.PropertyName)
-            {
-                CenterLabel.HeightRequest = CenterLabelHeightRequest;
             }
             else if (propertyName == RightButtonImageSourceProperty.PropertyName)
             {
@@ -146,17 +140,6 @@ namespace FHICORC.Views.Elements
             set { SetValue(CenterLabelTextProperty, value); }
         }
 
-        public static readonly BindableProperty CenterLabelHeightRequestProperty =
-            BindableProperty.Create(nameof(CenterLabelHeightRequest), typeof(int), typeof(Image), null,
-                BindingMode.OneWay);
-
-        public int CenterLabelHeightRequest
-        {
-            get { return (int)GetValue(CenterLabelHeightRequestProperty); }
-            set { SetValue(CenterLabelHeightRequestProperty, value); }
-        }
-
-
         public static readonly BindableProperty RightButtonImageSourceProperty =
             BindableProperty.Create(nameof(RightButtonImageSource), typeof(ImageSource), typeof(ImageButton),
                 null, BindingMode.OneWay);
@@ -166,7 +149,6 @@ namespace FHICORC.Views.Elements
             get { return (ImageSource)GetValue(RightButtonImageSourceProperty); }
             set { SetValue(RightButtonImageSourceProperty, value); }
         }
-
 
         public static readonly BindableProperty RightButtonCommandProperty =
             BindableProperty.Create(nameof(RightButtonCommand), typeof(Command), typeof(ImageButton), null,

--- a/FHICORC/Views/Menu/AboutPage.xaml
+++ b/FHICORC/Views/Menu/AboutPage.xaml
@@ -26,7 +26,6 @@
             <elements:NavigationHeader
                 CenterLabelText="{Binding Strings[ABOUT_PAGE_TITLE]}"
                 LeftButtonCommand="{Binding BackCommand}"
-                LeftButtonHeightRequest="40"
                 LeftButtonImageSource="{StaticResource ArrowBack}"/>
             <ScrollView Grid.Row="1" BackgroundColor="{StaticResource DefaultBackgroundColor}">
                 <ScrollView.Content>

--- a/FHICORC/Views/Menu/MenuHelpPage.xaml
+++ b/FHICORC/Views/Menu/MenuHelpPage.xaml
@@ -29,7 +29,6 @@
                 CenterLabelText="{Binding Strings[HELP_TITLE]}"
                 LeftButtonCommand="{Binding BackCommand}"
                 LeftButtonAccessibilityText="{Binding Strings[BACK_BUTTON]}"
-                LeftButtonHeightRequest="50"
                 LeftButtonImageSource="{StaticResource ArrowBack}"/>
 
             <ScrollView Grid.Row="1" BackgroundColor="{StaticResource DefaultBackgroundColor}">

--- a/FHICORC/Views/Menu/SettingsPage.xaml
+++ b/FHICORC/Views/Menu/SettingsPage.xaml
@@ -30,7 +30,6 @@
                 CenterLabelText="{Binding Strings[SETTINGS_TITLE]}"
                 LeftButtonCommand="{Binding BackCommand}"
                 LeftButtonAccessibilityText="{Binding Strings[BACK_BUTTON]}"
-                LeftButtonHeightRequest="50"
                 LeftButtonImageSource="{StaticResource ArrowBack}" />
             <ScrollView Grid.Row="1" BackgroundColor="{StaticResource DefaultBackgroundColor}">
                 <ScrollView.Content>


### PR DESCRIPTION
Example with wrapping:
![scan result](https://user-images.githubusercontent.com/97104440/154660298-d841e423-6561-4ce9-a163-bc58280380ea.jpg)
